### PR TITLE
fix(windows): Fix matching of path with backwards slash

### DIFF
--- a/lua/omnisharp_extended/utils.lua
+++ b/lua/omnisharp_extended/utils.lua
@@ -31,8 +31,18 @@ U.get_or_create_buf = function(name)
   local buffers = vim.api.nvim_list_bufs()
   for _, buf in pairs(buffers) do
     local bufname = vim.api.nvim_buf_get_name(buf)
-    if bufname == name then
-      return buf
+
+    -- if we are looking for $metadata$ buffer, search for entire string anywhere
+    -- in buffer name. On Windows nvim_buf_set_name might change the buffer name and include some stuff before.
+    if string.find(name, '^/%$metadata%$/.*$') then
+      local normalized_bufname = string.gsub(bufname, '\\', '/')
+      if string.find(normalized_bufname, name) then
+        return buf
+      end
+    else
+      if bufname == name then
+        return buf
+      end
     end
   end
 


### PR DESCRIPTION
resolves #4 

A bit cursed solution to work around paths. Main problem is that Windows seems to prepend some stuff to provided buffer name so it's not as simple as matching 1:1 strings. You can have paths like `file:///C:/Users/xxx/Documents/github/test3//$metadata$/Project/test3/Assembly/System/Runtime/Symbol/System/String.cs` whereas on unix this would just be `/$metadata$/Project/test3/Assembly/System/Runtime/Symbol/System/String.cs`.

Based on limited testing seems to now work on Windows and unix functionality is not broken.