### PR TITLE
Fix offset encoding and match for bufname

### DIFF
--- a/lua/omnisharp_extended.lua
+++ b/lua/omnisharp_extended.lua
@@ -158,7 +158,8 @@ M.handle_locations = function(locations)
       return true
     else
       -- utils.jump_to_location(locations[1], fetched[locations[1].uri].bufnr)
-      vim.lsp.util.jump_to_location(locations[1])
+      local offset_encoding = M.get_omnisharp_client().offset_encoding
+      vim.lsp.util.jump_to_location(locations[1], offset_encoding)
       return true
     end
   else
@@ -215,6 +216,7 @@ M.handle_locations_telescope = function(locations, opts)
 
   local fetched = M.get_metadata(locations)
 
+  local offset_encoding = M.get_omnisharp_client().offset_encoding
   if #locations == 0 then
     return
   elseif #locations == 1 and opts.jump_type ~= "never" then
@@ -225,9 +227,9 @@ M.handle_locations_telescope = function(locations, opts)
     elseif opts.jump_type == "vsplit" then
       vim.cmd "vnew"
     end
-    vim.lsp.util.jump_to_location(locations[1])
+    vim.lsp.util.jump_to_location(locations[1], offset_encoding)
   else
-    local locations = vim.lsp.util.locations_to_items(locations)
+    local locations = vim.lsp.util.locations_to_items(locations, offset_encoding)
     pickers.new(opts, {
       prompt_title = title,
       finder = finders.new_table {
@@ -281,7 +283,7 @@ end
 M.telescope_lsp_definitions = function(opts)
   local client = M.get_omnisharp_client()
   if client then
-    local params = vim.lsp.util.make_position_params()
+    local params = vim.lsp.util.make_position_params(0, client.offset_encoding)
 
     local handler = function(err, result, ctx, config)
       ctx.params = params
@@ -295,7 +297,7 @@ end
 M.lsp_definitions = function(opts)
   local client = M.get_omnisharp_client()
   if client then
-    local params = vim.lsp.util.make_position_params()
+    local params = vim.lsp.util.make_position_params(0, client.offset_encoding)
 
     local handler = function(err, result, ctx, config)
       ctx.params = params

--- a/lua/omnisharp_extended.lua
+++ b/lua/omnisharp_extended.lua
@@ -206,6 +206,8 @@ end
 
 M.handle_locations_telescope = function(locations, offset_encoding, opts)
   opts = opts or {}
+
+  local fetched = M.get_metadata(locations)
   if #locations == 0 then
     return
   elseif #locations == 1 and opts.jump_type ~= "never" then

--- a/lua/omnisharp_extended.lua
+++ b/lua/omnisharp_extended.lua
@@ -184,7 +184,7 @@ M.handler = function(err, result, ctx, config)
 
     local client = M.get_omnisharp_client()
     if client then
-      result, err = client.request_sync('o#/v2/gotodefinition', params, 10000)
+      local result, err = client.request_sync('o#/v2/gotodefinition', params, 10000)
       if err then
         vim.api.nvim_err_writeln('Error when executing ' .. 'o#/v2/gotodefinition' .. ' : ' .. err)
         return
@@ -257,7 +257,7 @@ M.handler_telescope = function(err, result, ctx, _)
 
     local client = M.get_omnisharp_client()
     if client then
-      result, err = client.request_sync('o#/v2/gotodefinition', params, 10000)
+      local result, err = client.request_sync('o#/v2/gotodefinition', params, 10000)
       if err then
         vim.api.nvim_err_writeln('Error when executing ' .. 'o#/v2/gotodefinition' .. ' : ' .. err)
         return

--- a/lua/omnisharp_extended/utils.lua
+++ b/lua/omnisharp_extended/utils.lua
@@ -36,7 +36,7 @@ U.get_or_create_buf = function(name)
     -- in buffer name. On Windows nvim_buf_set_name might change the buffer name and include some stuff before.
     if string.find(name, '^/%$metadata%$/.*$') then
       local normalized_bufname = string.gsub(bufname, '\\', '/')
-      if string.find(normalized_bufname, name) then
+      if string.find(normalized_bufname, name) or normalized_bufname == name then
         return buf
       end
     else
@@ -52,7 +52,8 @@ U.get_or_create_buf = function(name)
 end
 
 U.set_qflist_locations = function(locations)
-  local items = vim.lsp.util.locations_to_items(locations)
+  local offset_encoding = require('omnisharp_extended').get_omnisharp_client().offset_encoding
+  local items = vim.lsp.util.locations_to_items(locations, offset_encoding)
   vim.fn.setqflist({}, ' ', {
     title = 'Language Server';
     items = items;

--- a/lua/omnisharp_extended/utils.lua
+++ b/lua/omnisharp_extended/utils.lua
@@ -51,8 +51,7 @@ U.get_or_create_buf = function(name)
   return bufnr
 end
 
-U.set_qflist_locations = function(locations)
-  local offset_encoding = require('omnisharp_extended').get_omnisharp_client().offset_encoding
+U.set_qflist_locations = function(locations, offset_encoding)
   local items = vim.lsp.util.locations_to_items(locations, offset_encoding)
   vim.fn.setqflist({}, ' ', {
     title = 'Language Server';

--- a/lua/omnisharp_extended/utils.lua
+++ b/lua/omnisharp_extended/utils.lua
@@ -36,7 +36,7 @@ U.get_or_create_buf = function(name)
     -- in buffer name. On Windows nvim_buf_set_name might change the buffer name and include some stuff before.
     if string.find(name, '^/%$metadata%$/.*$') then
       local normalized_bufname = string.gsub(bufname, '\\', '/')
-      if string.find(normalized_bufname, name) or normalized_bufname == name then
+      if string.find(normalized_bufname, name, 1, true) then
         return buf
       end
     else


### PR DESCRIPTION
Hi! Thanks for the plugin! I tried to set it up, but got some errors. Offset encoding is now required for jump_to_location, so I added that everywhere it is required. I also had a bug where if I went to the definition and then went back. If I then tried to go to definition on the same thing again, it would error because string.find would return nil even though they were the same. I fixed that by adding an equal check as well.

In the second commit I just did a little cleaning of unused variables and removing stuff that wasn't used. As well as importing make_entry from telescope and adding a title to the picker.