### PR TITLE
Add support for omnisharp_mono lsp

### DIFF
--- a/lua/omnisharp_extended.lua
+++ b/lua/omnisharp_extended.lua
@@ -32,7 +32,7 @@ end
 M.get_omnisharp_client = function()
   local clients = vim.lsp.buf_get_clients(0)
   for _, client in pairs(clients) do
-    if client.name == "omnisharp" then
+    if client.name == "omnisharp" or client.name == "omnisharp_mono" then
       return client
     end
   end


### PR DESCRIPTION
Add support for omnisharp_mono. The plugin works perfectly with Omnisharp mono too, but currently, it can't find omnisharp_mono LSP.