### PR TITLE
feat(type-definition): add support for type-definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Extended LSP handlers and additional commands that support and are aware of Omni
 
 Currently supported commands:
 - `textDocument/definition`
+- `textDocument/typeDefinition`
 - `textDocument/references`
 - `textDocument/implementation`
 
@@ -23,6 +24,9 @@ Using provided custom command for each supported action:
 -- replaces vim.lsp.buf.definition()
 nnoremap gd <cmd>lua require('omnisharp_extended').lsp_definition()<cr>
 
+-- replaces vim.lsp.buf.type_definition()
+nnoremap <leader>D <cmd>lua require('omnisharp_extended').lsp_type_definition()<cr>
+
 -- replaces vim.lsp.buf.references()
 nnoremap gr <cmd>lua require('omnisharp_extended').lsp_references()<cr>
 
@@ -40,6 +44,7 @@ There are also commands provided specifically for [nvim-telescope](https://githu
 nnoremap gr <cmd>lua require('omnisharp_extended').telescope_lsp_references()<cr>
 -- options are supported as well
 nnoremap gd <cmd>lua require('omnisharp_extended').telescope_lsp_definition({ jump_type = "vsplit" })<cr>
+nnoremap <leader>D <cmd>lua require('omnisharp_extended').telescope_lsp_type_definition()<cr>
 nnoremap gi <cmd>lua require('omnisharp_extended').telescope_lsp_implementation()<cr>
 ```
 
@@ -52,6 +57,7 @@ local config = {
   ...
   handlers = {
     ["textDocument/definition"] = require('omnisharp_extended').definition_handler,
+    ["textDocument/typeDefinition"] = require('omnisharp_extended').type_definition_handler,
     ["textDocument/references"] = require('omnisharp_extended').references_handler,
     ["textDocument/implementation"] = require('omnisharp_extended').implementation_handler,
   },

--- a/lua/definition.lua
+++ b/lua/definition.lua
@@ -24,26 +24,6 @@ o#/v2/gotodefinition
         public SourceGeneratedFileInfo? SourceGeneratedFileInfo { get; init; }
     }
 
-o#/v2/gototypedefinition
-    public class GotoTypeDefinitionRequest : Request
-    {
-        public int Timeout { get; set; } = 10000;
-        public bool WantMetadata { get; set; }
-    }
-
-    public record GotoTypeDefinitionResponse
-    {
-        public List<TypeDefinition>? Definitions { get; init; }
-    }
-
-    public record TypeDefinition
-    {
-        public Location Location { get; init; } = null!;
-        public MetadataSource? MetadataSource { get; init; }
-        public SourceGeneratedFileInfo? SourceGeneratedFileInfo { get; init; }
-    }
-
-shared
     public record Location
     {
         public string FileName { get; init; } = null!;
@@ -82,7 +62,7 @@ shared
 
 function gotodefinition_to_locations(err, result, ctx, config)
   if err then
-    vim.api.nvim_err_writeln("Error when executing " .. ctx.method .. " : " .. err.message)
+    vim.api.nvim_err_writeln("Error when executing " .. "o#/v2/gotodefinition" .. " : " .. err.message)
   end
 
   local lsp_client = vim.lsp.get_client_by_id(ctx.client_id)
@@ -146,7 +126,7 @@ function gotodefinition_to_locations(err, result, ctx, config)
   return locations
 end
 
-local definitionGLsp = Command:new({
+local gLsp = Command:new({
   title = "LSP Definitions",
   lsp_cmd_name = "textDocument/definition",
   omnisharp_cmd_name = "o#/v2/gotodefinition",
@@ -155,36 +135,14 @@ local definitionGLsp = Command:new({
   telescope_location_callback = loc_utils.telescope_list_or_jump,
 })
 
-local typeDefinitionGLsp = Command:new({
-  title = "LSP Type Definitions",
-  lsp_cmd_name = "textDocument/typeDefinition",
-  omnisharp_cmd_name = "o#/gototypedefinition",
-  omnisharp_result_to_locations = gotodefinition_to_locations,
-  location_callback = loc_utils.qflist_list_or_jump,
-  telescope_location_callback = loc_utils.telescope_list_or_jump,
-})
-
 return {
-  definition = {
-    handler = function(err, result, ctx, config)
-      definitionGLsp:handler(err, result, ctx, config)
-    end,
-    omnisharp_command = function()
-      definitionGLsp:omnisharp_cmd()
-    end,
-    telescope_command = function(opts)
-      definitionGLsp:telescope_cmd(opts)
-    end,
-  },
-  typeDefinition = {
-    handler = function(err, result, ctx, config)
-      typeDefinitionGLsp:handler(err, result, ctx, config)
-    end,
-    omnisharp_command = function()
-      typeDefinitionGLsp:omnisharp_cmd()
-    end,
-    telescope_command = function(opts)
-      typeDefinitionGLsp:telescope_cmd(opts)
-    end,
-  },
+  handler = function(err, result, ctx, config)
+    gLsp:handler(err, result, ctx, config)
+  end,
+  omnisharp_command = function()
+    gLsp:omnisharp_cmd()
+  end,
+  telescope_command = function(opts)
+    gLsp:telescope_cmd(opts)
+  end,
 }

--- a/lua/omnisharp_extended.lua
+++ b/lua/omnisharp_extended.lua
@@ -1,5 +1,4 @@
 local m_definition = require("definition")
-local m_type_definition = require("type_definition")
 local m_references = require("references")
 local m_implementation = require("implementation")
 local o_utils = require("omnisharp_utils")
@@ -11,13 +10,13 @@ M.handler = m_definition.handler
 M.lsp_definitions = m_definition.omnisharp_command
 M.telescope_lsp_definitions = m_definition.telescope_command
 
-M.lsp_definition = m_definition.omnisharp_command
-M.telescope_lsp_definition = m_definition.telescope_command
-M.definition_handler = m_definition.handler
+M.lsp_definition = m_definition.definition.omnisharp_command
+M.telescope_lsp_definition = m_definition.definition.telescope_command
+M.definition_handler = m_definition.definition.handler
 
-M.lsp_type_definition = m_type_definition.omnisharp_command
-M.telescope_lsp_type_definition = m_type_definition.telescope_command
-M.type_definition_handler = m_type_definition.handler
+M.lsp_type_definition = m_definition.typeDefinition.omnisharp_command
+M.telescope_lsp_type_definition = m_definition.typeDefinition.telescope_command
+M.type_definition_handler = m_definition.typeDefinition.handler
 
 M.lsp_references = m_references.omnisharp_command
 M.telescope_lsp_references = m_references.telescope_command

--- a/lua/omnisharp_extended.lua
+++ b/lua/omnisharp_extended.lua
@@ -1,4 +1,5 @@
 local m_definition = require("definition")
+local m_type_definition = require("type_definition")
 local m_references = require("references")
 local m_implementation = require("implementation")
 local o_utils = require("omnisharp_utils")
@@ -10,13 +11,13 @@ M.handler = m_definition.handler
 M.lsp_definitions = m_definition.omnisharp_command
 M.telescope_lsp_definitions = m_definition.telescope_command
 
-M.lsp_definition = m_definition.definition.omnisharp_command
-M.telescope_lsp_definition = m_definition.definition.telescope_command
-M.definition_handler = m_definition.definition.handler
+M.lsp_definition = m_definition.omnisharp_command
+M.telescope_lsp_definition = m_definition.telescope_command
+M.definition_handler = m_definition.handler
 
-M.lsp_type_definition = m_definition.typeDefinition.omnisharp_command
-M.telescope_lsp_type_definition = m_definition.typeDefinition.telescope_command
-M.type_definition_handler = m_definition.typeDefinition.handler
+M.lsp_type_definition = m_type_definition.omnisharp_command
+M.telescope_lsp_type_definition = m_type_definition.telescope_command
+M.type_definition_handler = m_type_definition.handler
 
 M.lsp_references = m_references.omnisharp_command
 M.telescope_lsp_references = m_references.telescope_command

--- a/lua/omnisharp_extended.lua
+++ b/lua/omnisharp_extended.lua
@@ -1,4 +1,5 @@
 local m_definition = require("definition")
+local m_type_definition = require("type_definition")
 local m_references = require("references")
 local m_implementation = require("implementation")
 local o_utils = require("omnisharp_utils")
@@ -10,10 +11,13 @@ M.handler = m_definition.handler
 M.lsp_definitions = m_definition.omnisharp_command
 M.telescope_lsp_definitions = m_definition.telescope_command
 
-
 M.lsp_definition = m_definition.omnisharp_command
 M.telescope_lsp_definition = m_definition.telescope_command
 M.definition_handler = m_definition.handler
+
+M.lsp_type_definition = m_type_definition.omnisharp_command
+M.telescope_lsp_type_definition = m_type_definition.telescope_command
+M.type_definition_handler = m_type_definition.handler
 
 M.lsp_references = m_references.omnisharp_command
 M.telescope_lsp_references = m_references.telescope_command

--- a/lua/type_definition.lua
+++ b/lua/type_definition.lua
@@ -1,0 +1,148 @@
+local o_utils = require("omnisharp_utils")
+local loc_utils = require("location_utils")
+local Command = require("generic_command")
+
+--[[
+OmniSharp Protocol:
+
+o#/v2/gototypedefinition
+    public class GotoTypeDefinitionRequest : Request
+    {
+        public int Timeout { get; set; } = 10000;
+        public bool WantMetadata { get; set; }
+    }
+
+    public record GotoTypeDefinitionResponse
+    {
+        public List<TypeDefinition>? Definitions { get; init; }
+    }
+
+    public record TypeDefinition
+    {
+        public Location Location { get; init; } = null!;
+        public MetadataSource? MetadataSource { get; init; }
+        public SourceGeneratedFileInfo? SourceGeneratedFileInfo { get; init; }
+    }
+
+    public record Location
+    {
+        public string FileName { get; init; } = null!;
+        public Range Range { get; init; } = null!;
+    }
+
+    public record Range
+    {
+        public Point Start { get; init; }
+        public Point End { get; init; }
+    }
+
+    public record Point : IEquatable<Point>
+    {
+        [JsonConverter(typeof(ZeroBasedIndexConverter))]
+        public int Line { get; init; }
+        [JsonConverter(typeof(ZeroBasedIndexConverter))]
+        public int Column { get; init; }
+    }
+
+    public class MetadataSource
+    {
+        public string AssemblyName { get; set; }
+        public string TypeName { get; set; }
+        public string ProjectName { get; set; }
+        public string VersionNumber { get; set; }
+        public string Language { get; set; }
+    }
+
+    public record SourceGeneratedFileInfo
+    {
+        public Guid ProjectGuid { get; init; }
+        public Guid DocumentGuid { get; init; }
+    }
+--]]
+
+function gototypedefinition_to_locations(err, result, ctx, config)
+  if err then
+    vim.api.nvim_err_writeln("Error when executing " .. "o#/gototypedefinition" .. " : " .. err.message)
+  end
+
+  local lsp_client = vim.lsp.get_client_by_id(ctx.client_id)
+  local locations = {}
+
+  if not result or not result.Definitions then
+    return locations
+  end
+
+  for _, typedefinition in ipairs(result.Definitions) do
+    -- load metadata file if available
+
+    local buf_file_name = typedefinition.Location.FileName
+    if typedefinition.MetadataSource then
+      local params = {
+        timeout = 5000,
+      }
+
+      -- matches what request expects
+      for k, v in pairs(typedefinition.MetadataSource) do
+        params[k] = v
+      end
+
+      _, buf_file_name = o_utils.load_metadata_doc(params, lsp_client)
+    end
+
+    -- load sourcegenerated file if available
+    if typedefinition.SourceGeneratedFileInfo then
+      local params = {
+        timeout = 5000,
+      }
+
+      -- matches what request expects
+      for k, v in pairs(typedefinition.SourceGeneratedFileInfo) do
+        params[k] = v
+      end
+
+      _, buf_file_name = o_utils.load_sourcegen_doc(params, lsp_client)
+    end
+
+    -- remap typedefinition to nvim lsp location
+    local range = {}
+    range["start"] = {
+      line = typedefinition.Location.Range.Start.Line,
+      character = typedefinition.Location.Range.Start.Column,
+    }
+    range["end"] = {
+      line = typedefinition.Location.Range.End.Line,
+      character = typedefinition.Location.Range.End.Column,
+    }
+
+    if buf_file_name ~= nil then
+      local location = {
+        uri = "file://" .. buf_file_name,
+        range = range,
+      }
+      table.insert(locations, location)
+    end
+  end
+
+  return locations
+end
+
+local gLsp = Command:new({
+  title = "LSP TypeDefinitions",
+  lsp_cmd_name = "textDocument/typeDefinition",
+  omnisharp_cmd_name = "o#/gototypedefinition",
+  omnisharp_result_to_locations = gototypedefinition_to_locations,
+  location_callback = loc_utils.qflist_list_or_jump,
+  telescope_location_callback = loc_utils.telescope_list_or_jump,
+})
+
+return {
+  handler = function(err, result, ctx, config)
+    gLsp:handler(err, result, ctx, config)
+  end,
+  omnisharp_command = function()
+    gLsp:omnisharp_cmd()
+  end,
+  telescope_command = function(opts)
+    gLsp:telescope_cmd(opts)
+  end,
+}


### PR DESCRIPTION
Implements jump to type definition, useful for objects with types from third party libraries.
(addresses issue #26 )

Refactors error message in definition to extract method name from context,
thereby allowing reuse of method for both `definition` and `typeDefinition`.

(This is my first PR to open source code, so any feedback is very welcome)