### PR TITLE
Fix remove deprecated functions

### DIFF
--- a/lua/generic_command.lua
+++ b/lua/generic_command.lua
@@ -1,9 +1,10 @@
 local utils = require("omnisharp_extended/utils")
 local o_utils = require("omnisharp_utils")
 local loc_utils = require("location_utils")
+local islist = vim.islist or vim.tbl_islist
 
 function flatten_lsp_locations(result)
-  if not vim.tbl_islist(result) then
+  if not islist(result) then
     return { result }
   end
 

--- a/lua/omnisharp_extended/utils.lua
+++ b/lua/omnisharp_extended/utils.lua
@@ -74,7 +74,13 @@ U.file_exists = function(name)
 end
 
 U.get_omnisharp_client = function()
-  local clients = vim.lsp.buf_get_clients(0)
+  local clients = nil;
+  if vim.lsp.get_clients ~= nil then
+    clients = vim.lsp.get_clients({ buffer = 0 })
+  else
+    clients = vim.lsp.buf_get_clients(0)
+  end
+
   for _, client in pairs(clients) do
     if client.name == "omnisharp" or client.name == "omnisharp_mono" then
       return client


### PR DESCRIPTION
I am using Below neovim version.

NVIM v0.11.0-dev-15+g62eb7e79a
Build type: RelWithDebInfo
LuaJIT 2.1.1713484068

Whenever i was doing a "GoToDefinition" action, I was getting warning messages for deprecated functions. 


Deprecated functions being:

1. `vim.tbl_islist`. The preferred function now is `vim.islist`.
2. `vim.lsp.buf_get_clients`. The preferred function now is `vim.lsp.get_clients`. 

I have still kept the deprecated functions as fallback. 

After making these changes, i was not getting those warning messages. 