### PR TITLE
fix: prefer show_document over deprecated jump_to_location

### DIFF
--- a/lua/location_utils.lua
+++ b/lua/location_utils.lua
@@ -28,7 +28,11 @@ M.telescope_list_or_jump = function(title, params, locations, lsp_client, opts)
       end
     end
 
-    vim.lsp.util.jump_to_location(locations[1], lsp_client.offset_encoding, opts.reuse_win)
+    if vim.lsp.util.show_document ~= nil then
+      vim.lsp.util.show_document(locations[1], lsp_client.offset_encoding, { reuse_win = opts.reuse_win })
+    else
+      vim.lsp.util.jump_to_location(locations[1], lsp_client.offset_encoding, opts.reuse_win)
+    end
   else
     locations = vim.lsp.util.locations_to_items(locations, lsp_client.offset_encoding)
     pickers
@@ -62,7 +66,8 @@ M.qflist_list_or_jump = function(locations, lsp_client)
     utils.set_qflist_locations(locations, lsp_client.offset_encoding)
     vim.api.nvim_command("copen")
   elseif #locations == 1 then
-    vim.lsp.util.jump_to_location(locations[1], lsp_client.offset_encoding)
+    local show_document = vim.lsp.util.show_document or vim.lsp.util.jump_to_location
+    show_document(locations[1], lsp_client.offset_encoding)
   else
     vim.notify("No locations found")
   end

--- a/lua/omnisharp_extended/utils.lua
+++ b/lua/omnisharp_extended/utils.lua
@@ -52,17 +52,6 @@ U.set_qflist_locations = function(locations, offset_encoding)
   })
 end
 
-U.jump_to_location = function(location, bufnr)
-  if not bufnr then
-    -- if bufnr is provided, assume its configured
-    bufnr = vim.uri_to_bufnr(location.uri)
-    vim.api.nvim_buf_set_option(0, "buflisted", true)
-  end
-
-  vim.api.nvim_set_current_buf(bufnr)
-  vim.api.nvim_win_set_cursor(0, { location.range.start.line + 1, location.range.start.character })
-end
-
 U.file_exists = function(name)
   local f = io.open(name, "r")
   if f ~= nil then


### PR DESCRIPTION
In the latest nightly Neovim I get many deprecataction messages when I use go to definition:

> vim.lsp.util.jump_to_location is deprecated. Run ":checkhealth vim.deprecated" for more information                          

Version:

```
NVIM v0.11.0-dev
Build type: Release
LuaJIT 2.1.1713773202
```

