### PR TITLE
Fixed issue: omnisharp_utils.lua:152: attempt to index local 'opts' (a nil value)

### DIFF
--- a/lua/generic_command.lua
+++ b/lua/generic_command.lua
@@ -17,7 +17,7 @@ local Command = {
   omnisharp_cmd_name = "o#/v2/gotodefinition",
   omnisharp_result_to_locations = function(err, result, ctx, config) end,
   location_callback = function(locations, lsp_client) end,
-  telescope_location_callback = function(locations, r_params, lsp_client, telescope_opts) end,
+  telescope_location_callback = function(title, params, locations, lsp_client, opts) end,
 }
 
 function Command:new(o)
@@ -64,15 +64,12 @@ function Command:telescope_cmd(opts)
   if not telescope_exists then
     error("Telescope is not available, this function only works with Telescope.")
   end
-
-  opts = opts or {}
   local client = utils.get_omnisharp_client()
   if client then
     -- closure with passed in telescope options
     local handler = function(err, result, ctx, config)
       self:telescope_cmd_handler(err, result, ctx, config, opts)
     end
-
     client.request(self.omnisharp_cmd_name, o_utils.cmd_params(client, opts), handler)
   end
 end

--- a/lua/location_utils.lua
+++ b/lua/location_utils.lua
@@ -12,6 +12,7 @@ M.telescope_list_or_jump = function(title, params, locations, lsp_client, opts)
   local pickers = require("telescope.pickers")
   local finders = require("telescope.finders")
   local conf = require("telescope.config").values
+  opts = opts or {}
 
   if #locations == 0 then
     vim.notify("No locations found")

--- a/lua/omnisharp_utils.lua
+++ b/lua/omnisharp_utils.lua
@@ -145,11 +145,12 @@ end
 
 OU.cmd_params = function(lsp_client, opts)
   local params = vim.lsp.util.make_position_params(0, lsp_client.offset_encoding)
+  local excludeDefinition = (opts and opts.excludeDefinition) or false
   return {
     fileName = OU.file_name_for_omnisharp(params.textDocument.uri),
     column = params.position.character,
     line = params.position.line,
-    excludeDefinition = opts.excludeDefinition or false,
+    excludeDefinition = excludeDefinition
   }
 end
 


### PR DESCRIPTION
https://github.com/Hoffs/omnisharp-extended-lsp.nvim/pull/48 introduced an issue with the non-telescope command methods (lua/omnisharp_utils.lua@152).
```
E5108: Error executing lua ...lazy/omnisharp-extended-lsp.nvim/lua/omnisharp_utils.lua:152: attempt to index local 'opts' (a nil value)
stack traceback:
        ...lazy/omnisharp-extended-lsp.nvim/lua/omnisharp_utils.lua:152: in function 'cmd_params'
        ...lazy/omnisharp-extended-lsp.nvim/lua/generic_command.lua:39: in function 'omnisharp_cmd'
        ...nvim/lazy/omnisharp-extended-lsp.nvim/lua/definition.lua:143: in function 'lsp_definition'
```

Options is not passed to `cmd_params()` from `Command:omnisharp_cmd()`.

Feel free to adjust as you see fit.

Thanks for this plug in!