### PR TITLE
fix: go to definition not working due to nil values

### DIFF
--- a/lua/definition.lua
+++ b/lua/definition.lua
@@ -76,7 +76,7 @@ function gotodefinition_to_locations(err, result, ctx, config)
     -- load metadata file if available
 
     local buf_file_name = definition.Location.FileName
-    if definition.MetadataSource then
+    if definition.MetadataSource ~= vim.NIL then
       local params = {
         timeout = 5000,
       }
@@ -90,7 +90,7 @@ function gotodefinition_to_locations(err, result, ctx, config)
     end
 
     -- load sourcegenerated file if available
-    if definition.SourceGeneratedFileInfo then
+    if definition.SourceGeneratedFileInfo ~= vim.NIL then
       local params = {
         timeout = 5000,
       }

--- a/lua/omnisharp_utils.lua
+++ b/lua/omnisharp_utils.lua
@@ -108,7 +108,7 @@ OU.quickfixes_to_locations = function(quickfixes, lsp_client)
     local buf_file_name = qf.FileName
 
     -- load sourcegenerated file if available
-    if qf.GeneratedFileInfo then
+    if qf.GeneratedFileInfo ~= vim.NIL then
       local params = {
         timeout = 5000,
       }


### PR DESCRIPTION
Since 1 week or 2, I was unable to use the gotodefinition in c# code (other lsp features were working fine tho).

I found this workaround, I don't know if it's legit this I know how this plugin works exactly, what changes caused the regression (and how lua works exactly).

I open this PR to open the discussion.