### PR TITLE
Add vim.NIL checks for definition results

### DIFF
--- a/lua/definition.lua
+++ b/lua/definition.lua
@@ -68,7 +68,7 @@ function gotodefinition_to_locations(err, result, ctx, config)
   local lsp_client = vim.lsp.get_client_by_id(ctx.client_id)
   local locations = {}
 
-  if not result or not result.Definitions then
+  if not result or not result.Definitions or result.Definitions == vim.NIL then
     return locations
   end
 

--- a/lua/implementation.lua
+++ b/lua/implementation.lua
@@ -70,7 +70,7 @@ function implementations_to_locations(err, result, ctx, config)
   local lsp_client = vim.lsp.get_client_by_id(ctx.client_id)
   local locations = {}
 
-  if not result or not result.QuickFixes then
+  if not result or not result.QuickFixes or result.QuickFixes == vim.NIL then
     return {}
   end
 

--- a/lua/references.lua
+++ b/lua/references.lua
@@ -72,7 +72,7 @@ function usages_to_locations(err, result, ctx, config)
 
   local lsp_client = vim.lsp.get_client_by_id(ctx.client_id)
 
-  if not result or not result.QuickFixes then
+  if not result or not result.QuickFixes or result.QuickFixes == vim.NIL then
     return {}
   end
 

--- a/lua/type_definition.lua
+++ b/lua/type_definition.lua
@@ -68,7 +68,7 @@ function gototypedefinition_to_locations(err, result, ctx, config)
   local lsp_client = vim.lsp.get_client_by_id(ctx.client_id)
   local locations = {}
 
-  if not result or not result.Definitions then
+  if not result or not result.Definitions or result.Definitions == vim.NIL then
     return locations
   end
 


### PR DESCRIPTION
Fix issues like below while navigating with "go to definition" by checking vim.NIL specifically

```
vim.schedule callback: ...nvim/lazy/omnisharp-extended-lsp.nvim/lua/definition.lua:75: bad argument #1 to 'ipairs' (table expected, got userdata)
  stack traceback:
          [C]: in function 'ipairs'
          ...nvim/lazy/omnisharp-extended-lsp.nvim/lua/definition.lua:75: in function 'omnisharp_result_to_locations'
          ...lazy/omnisharp-extended-lsp.nvim/lua/generic_command.lua:32: in function 'omnisharp_cmd_handler'
          ...lazy/omnisharp-extended-lsp.nvim/lua/generic_command.lua:40: in function 'handler'
          /usr/share/nvim/runtime/lua/vim/lsp/client.lua:742: in function ''
          vim/_core/editor.lua: in function <vim/_core/editor.lua:0>
```