### PR TITLE
fix: deprecated warning by replacing client.request with client:request

### DIFF
--- a/lua/generic_command.lua
+++ b/lua/generic_command.lua
@@ -36,7 +36,7 @@ end
 function Command:omnisharp_cmd()
   local client = utils.get_omnisharp_client()
   if client then
-    client.request(self.omnisharp_cmd_name, o_utils.cmd_params(client), function(err, result, ctx, config)
+    client:request(self.omnisharp_cmd_name, o_utils.cmd_params(client), function(err, result, ctx, config)
       self:omnisharp_cmd_handler(err, result, ctx, config)
     end)
   end
@@ -70,7 +70,7 @@ function Command:telescope_cmd(opts)
     local handler = function(err, result, ctx, config)
       self:telescope_cmd_handler(err, result, ctx, config, opts)
     end
-    client.request(self.omnisharp_cmd_name, o_utils.cmd_params(client, opts), handler)
+    client:request(self.omnisharp_cmd_name, o_utils.cmd_params(client, opts), handler)
   end
 end
 

--- a/lua/omnisharp_utils.lua
+++ b/lua/omnisharp_utils.lua
@@ -43,7 +43,7 @@ o#/sourcegeneratedfile
 --   Language
 -- }
 OU.load_metadata_doc = function(params, lsp_client)
-  local result, err = lsp_client.request_sync("o#/metadata", params, 10000)
+  local result, err = lsp_client:request_sync("o#/metadata", params, 10000)
   if not err then
     local response = result.result
 
@@ -67,7 +67,7 @@ end
 -- }
 OU.load_sourcegen_doc = function(params, lsp_client)
   params.timeout = 5000
-  local result, err = lsp_client.request_sync("o#/sourcegeneratedfile", params, 10000)
+  local result, err = lsp_client:request_sync("o#/sourcegeneratedfile", params, 10000)
   if not err then
     -- Creates a buffer from sourcegeneratedfile response.
     local response = result.result


### PR DESCRIPTION
Fixes below deprecated warnings from `:checkhealth`

- ⚠️ WARNING client.request is deprecated. Feature will be removed in Nvim 0.13
    - ADVICE:
      - use client:request instead.
      - stack traceback:
          ~/.local/share/nvim/lazy/omnisharp-extended-lsp.nvim/lua/generic_command.lua:39

- ⚠️ WARNING client.request_sync is deprecated. Feature will be removed in Nvim 0.13
    - ADVICE:
      - use client:request_sync instead.
      - stack traceback:
          ~/.local/share/nvim/lazy/omnisharp-extended-lsp.nvim/lua/omnisharp_utils.lua:70